### PR TITLE
fix: added dependencies to docs/requirement.txt to fix rtd docs bug

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,12 @@
 sphinx==8.1.3
 sphinx-rtd-theme==3.0.2
+aisuite[ollama]==0.1.10 
+scikit-learn==1.6.1
+ktrain==0.41.4
+docstring_parser==0.16
+ollama==0.4.7
+langchain-text-splitters==0.3.6
+PyMuPDF==1.25.3
+tiktoken==0.9.0
+networkx==3.4.2
+tqdm==4.67.1


### PR DESCRIPTION
PR for #12 

## Issue
- the issue lied in the `docs/requirements.txt`
- Logs of deployed docs on `rtd`
```bash
Running Sphinx v8.1.3
loading translations [en]... done
making output directory... done
WARNING: html_static_path entry '_static' does not exist
[autosummary] generating autosummary for: graphrag_tagger.chat.rst, graphrag_tagger.lda.rst, graphrag_tagger.rst, index.rst, modules.rst
WARNING: Failed to import graphrag_tagger.chat.llm.
Possible hints:
* ModuleNotFoundError: No module named 'aisuite'
* AttributeError: module 'graphrag_tagger.chat' has no attribute 'llm'
WARNING: Failed to import graphrag_tagger.lda.kt_modelling.
Possible hints:
* ModuleNotFoundError: No module named 'ktrain'
* AttributeError: module 'graphrag_tagger.lda' has no attribute 'kt_modelling'
WARNING: Failed to import graphrag_tagger.lda.sk_modelling.
```
- `rtd` needs to install the dependencies because Sphinx uses `autodoc` to import the modules and extract `docstrings`. If a module depends on an external package, Sphinx will fail to import it, causing the documentation build to break, and that what's happening all along.

## Solution
- I added dependencies from `requirements.txt` to `docs/requirements.txt`. 
- Here's a [test deployment](https://test-graphrag-tagger.readthedocs.io/en/latest/).